### PR TITLE
Fix Cloudflare tokens issuance domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Home page: **[https://privacypass.github.io][pp-home]**
 **Privacy Pass Providers:**  🟩 [Cloudflare][cf-url]  🟩 [hCaptcha][hc-url]
 
 [pp-home]: https://privacypass.github.io/
-[cf-url]: https://captcha.website/
+[cf-url]: https://issuance.privacypass.cloudflare.com/
 [hc-url]: https://www.hcaptcha.com/privacy-pass/
 [chrome-store]: https://chrome.google.com/webstore/detail/privacy-pass/ajhmfdgkijocedmfjonnpjfojldioehi/
 [firefox-store]: https://addons.mozilla.org/firefox/addon/privacy-pass/

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -113,11 +113,14 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
 // TODO It's better to move this to the provider class. Let's figure out how to do it later.
 // Removes cookies for captcha.website to enable getting more tokens in the future.
 chrome.cookies.onChanged.addListener((changeInfo) => {
-    if (
-        !changeInfo.removed &&
-        changeInfo.cookie.domain === '.captcha.website' &&
-        changeInfo.cookie.name === 'cf_clearance'
-    ) {
-        chrome.cookies.remove({ url: 'https://captcha.website', name: 'cf_clearance' });
+    const cloudflareDomains = ['captcha.website', 'issuance.privacypass.cloudflare.com']
+    for (const domain of cloudflareDomains) {
+        if (
+            !changeInfo.removed &&
+            changeInfo.cookie.domain === `.${domain}` &&
+            changeInfo.cookie.name === 'cf_clearance'
+        ) {
+            chrome.cookies.remove({ url: `https://${domain}`, name: 'cf_clearance' });
+        }
     }
 });

--- a/src/background/providers/cloudflare.ts
+++ b/src/background/providers/cloudflare.ts
@@ -17,7 +17,7 @@ const COMMITMENT_URL =
 const QUALIFIED_BODY_PARAMS = ['md'];
 
 const CHL_BYPASS_SUPPORT = 'cf-chl-bypass';
-const DEFAULT_ISSUING_HOSTNAME = 'captcha.website';
+const DEFAULT_ISSUING_HOSTNAME = 'issuance.privacypass.cloudflare.com';
 
 const REFERER_QUERY_PARAM = '__cf_chl_tk';
 const QUERY_PARAM = '__cf_chl_f_tk';

--- a/src/popup/components/CloudflareButton/index.tsx
+++ b/src/popup/components/CloudflareButton/index.tsx
@@ -12,7 +12,7 @@ export function CloudflareButton(): JSX.Element {
     });
 
     const openHomePage = () => {
-        chrome.tabs.create({ url: 'https://captcha.website' });
+        chrome.tabs.create({ url: 'https://issuance.privacypass.cloudflare.com' });
     };
 
     return (


### PR DESCRIPTION
Move from captcha.website to issuance.privacypass.cloudflare.com. This makes Cloudflare more identifiable as an issuer for Cloudflare tokens.