### PR TITLE
Fix Chromium MV3 extension

### DIFF
--- a/platform/mv3/chromium/index.ts
+++ b/platform/mv3/chromium/index.ts
@@ -1,5 +1,6 @@
 import {
     BROWSERS,
+    handleBeforeRequest,
     handleBeforeSendHeaders,
     handleHeadersReceived,
     handleInstall,
@@ -9,6 +10,8 @@ const BROWSER = BROWSERS.CHROME;
 const STORAGE = chrome.storage.local;
 
 chrome.runtime.onInstalled.addListener(handleInstall(STORAGE));
+
+chrome.webRequest.onBeforeRequest.addListener(handleBeforeRequest(), { urls: ['<all_urls>'] });
 
 chrome.webRequest.onBeforeSendHeaders.addListener(
     handleBeforeSendHeaders(STORAGE),

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -236,9 +236,9 @@ export const handleHeadersReceived =
             initiator = details.url;
         } else {
             initiator =
-                details.initiator ??
                 details.frameAncestors?.at(0)?.url ??
-                cachedTabs[details.tabId]?.url;
+                cachedTabs[details.tabId]?.url ??
+                details.initiator;
         }
         if (!initiator) {
             return;


### PR DESCRIPTION
Chromium MV2 used `onBeforeRequest`, which was not replicated for `MV3`. This commit addresses this issue.

In addition, cached initiator URL takes precedence over details provided initiator, which might not reflect the main frame domain.