### PR TITLE
Update GitHub actions and developer docs with new repository name

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_bug.md
+++ b/.github/ISSUE_TEMPLATE/new_bug.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Before reporting a new bug, verify if your request is already being tracked by another issue: https://github.com/privacypass/challenge-bypass-extension/issues.
+Before reporting a new bug, verify if your request is already being tracked by another issue: https://github.com/cloudflare/pp-browser-extension/issues.
 
 ---
 
@@ -28,10 +28,10 @@ A description of what is expected to happen.
 
 **System (please complete the following information):**
  - OS: [e.g. iOS/Windows]
- - Cloudflare tokens or hCaptcha tokens?
- - Browser [e.g. chrome, firefox]
+ - Attesters configuration from extension options
+ - Browser [e.g. Chrome, Firefox]
  - Browser Version [e.g. 79, 80, ]
- - Privacy Pass Version [e.g. 2.0.4, 2.0.5 ]
+ - Silk Version [e.g. 4.0.0, 4.0.1 ]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,11 +1,11 @@
 ---
-name: PrivacyPass Challenge Extension
+name: Silk Privacy Pass Client Extension
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   testing:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 Code is written in TypeScript and is automatically formatted with prettier.
 
-```
- $ npm run lint -- --fix
+```bash
+npm run format
 ```
 
 ### Naming convention

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,10 +1,11 @@
 ## Directory Structure
 
 ```
-challenge-bypass-extension
+pp-browser-extension
+├──📂 platform: Contains platform specific assets, such as manifest for browsers, or brackground and service worker script used by each platform.
 ├──📂 public: Contains all the assets which are neither the business logic files nor the style sheets.
 └──📂 src: Contains all the business logic files and the style sheets.
-    └──📂 privacypass: The business logic of the extension service worker.
-    └──📂 blindrsa: The cryptographic library for RSA operations.
-    └──📂 popup: The web app for the popup in the browser toolbar.
+    └──📂 background: The business logic of the extension service worker.
+    └──📂 common: The shared logic between the extension background script and its options context.
+    └──📂 options: The web app defining option page in the browser settings.
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![github release](https://img.shields.io/github/release/privacypass/challenge-bypass-extension.svg)](https://github.com/privacypass/challenge-bypass-extension/releases/)
-[![Privacy Pass](https://github.com/privacypass/challenge-bypass-extension/actions/workflows/action.yml/badge.svg)](https://github.com/privacypass/challenge-bypass-extension/actions)
+[![github release](https://img.shields.io/github/release/cloudflare/pp-browser-extension.svg)](https://github.com/cloudflare/pp-browser-extension/releases/)
+[![Privacy Pass](https://github.com/cloudflare/pp-browser-extension/actions/workflows/action.yml/badge.svg)](https://github.com/cloudflare/pp-browser-extension/actions)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 # Silk - Privacy Pass Client for the browser
@@ -18,8 +18,6 @@ This browser extension implements the client-side of the Privacy Pass protocol p
 * 🚧 Rate limited tokens
 
 
-Home page: **[https://privacypass.github.io][pp-home]**
-
 ## Installation
 
 | **[Chrome][chrome-store]** | **[Firefox][firefox-store]** |
@@ -30,7 +28,6 @@ Home page: **[https://privacypass.github.io][pp-home]**
 
 **Privacy Pass Attesters:**  🟩 [Cloudflare Research with Turnstile][cf-url]
 
-[pp-home]: https://privacypass.github.io/
 [cf-url]: https://pp-attester-turnstile.research.cloudflare.com/
 [chrome-store]: https://chrome.google.com/webstore/detail/privacy-pass/ajhmfdgkijocedmfjonnpjfojldioehi/
 [firefox-store]: https://addons.mozilla.org/firefox/addon/privacy-pass/
@@ -52,7 +49,7 @@ We recommend to install the extension using the official browser stores listed i
 ### Building
 
 ```sh
-git clone https://github.com/privacypass/challenge-bypass-extension
+git clone https://github.com/cloudflare/pp-browser-extension
 nvm use 16
 npm ci
 npm run build
@@ -98,17 +95,17 @@ npm test
 
 ### Highlights
 
-**2018** -- The Privacy Pass protocol is based on a _Verifiable, Oblivious Pseudorandom Function_ (VOPRF) first established by [Jarecki et al. 2014](https://eprint.iacr.org/2014/650.pdf). The details of the protocol were published at [PoPETS 2018](https://doi.org/10.1515/popets-2018-0026) paper authored by Alex Davidson, Ian Goldberg, Nick Sullivan, George Tankersley, and Filippo Valsorda.
-
-**2019** -- The captcha provider [hCaptcha](https://www.hcaptcha.com/privacy-pass) announced support for Privacy Pass, and the [v2](https://github.com/privacypass/challenge-bypass-extension/tree/2.0.0) version was released.
-
-**2020** -- The CFRG (part of IRTF/IETF) started a [working group](https://datatracker.ietf.org/wg/privacypass/about/) seeking for the standardization of the Privacy Pass protocol.
-
-**2021** -- In this [blog post](https://blog.cloudflare.com/privacy-pass-v3), we announced the [v3](https://github.com/privacypass/challenge-bypass-extension/tree/v3.0.0) version of this extension, which makes the code base more resilient, extensible, and maintainable.
+**2023** -- The extension updates to Privacy Pass Protocol draft 16, with the cryptographic part in a dedicated library [cloudflare/privacypass-ts](https://github.com/cloudflare/privacypass-ts). Introducing the notion of Attesters and Issuers.
 
 **2022** -- The Privacy Pass protocol can also use RSA blind signatures.
 
-**2023** -- The extension updates to Privacy Pass Protocol draft 16, with the cryptographic part in a dedicated library [cloudflare/privacypass-ts](https://github.com/cloudflare/privacypass-ts). Introducing the notion of Attesters and Issuers.
+**2021** -- In this [blog post](https://blog.cloudflare.com/privacy-pass-v3), we announced the [v3](https://github.com/cloudflare/pp-browser-extension/tree/v3.0.0) version of this extension, which makes the code base more resilient, extensible, and maintainable.
+
+**2020** -- The CFRG (part of IRTF/IETF) started a [working group](https://datatracker.ietf.org/wg/privacypass/about/) seeking for the standardization of the Privacy Pass protocol.
+
+**2019** -- The CAPTCHA provider [hCaptcha](https://www.hcaptcha.com/privacy-pass) announced support for Privacy Pass, and the [v2](https://github.com/cloudflare/pp-browser-extension/tree/2.0.0) version was released.
+
+**2018** -- The Privacy Pass protocol is based on a _Verifiable, Oblivious Pseudorandom Function_ (VOPRF) first established by [Jarecki et al. 2014](https://eprint.iacr.org/2014/650.pdf). The details of the protocol were published at [PoPETS 2018](https://doi.org/10.1515/popets-2018-0026) paper authored by Alex Davidson, Ian Goldberg, Nick Sullivan, George Tankersley, and Filippo Valsorda. Its homepage is still available at [https://privacypass.github.io](https://privacypass.github.io/).
 
 #### Acknowledgements
 

--- a/devel.md
+++ b/devel.md
@@ -3,7 +3,7 @@
 In a terminal:
 
 ```sh
-$ git clone https://github.com/armfazh/challenge-bypass-extension
+$ git clone https://github.com/cloudflare/pp-browser-extension
 $ nvm use 20 // it should work with Node v16+.
 $ npm ci
 $ npm run build
@@ -21,6 +21,6 @@ In Chrome:
 
 1. Open the Service worker & Devtools of a blank tab.
 
-1. Navigate to https://demo-origin.pat-issuer.cloudflare.com/type2 As you can see, we must specify type=2.
+1. Navigate to https://demo-pat.research.cloudflare.com/login.
 
-1. The behaviour expected is that browser first receives a 401 error, which is catched by the extension and then a reload that brings the body 'Token OK'.
+1. The behaviour expected is that browser first receives a 401 error, which is catched by the extension and then a reload that brings the body 'Token OK'. Chrome extension uses a replay mechanism documented in the [README](./README.md) as request blocking is not supported.

--- a/devel_pat.md
+++ b/devel_pat.md
@@ -40,7 +40,7 @@ body was fetched!!
 In a terminal:
 
 ```sh
-$ git clone https://github.com/armfazh/challenge-bypass-extension --branch = declNetReq
+$ git clone https://github.com/cloudflare/pp-browser-extension
 $ nvm use 18 // it should work with Node v16+.
 $ npm ci
 $ npm run build

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -228,6 +228,10 @@ export const handleHeadersReceived =
         }
 
         const settings = getSettings();
+        if (Object.keys(settings).length === 0) {
+            getRawSettings(storage);
+            return;
+        }
         const { attesters, serviceWorkerMode: mode } = settings;
         const logger = getLogger(mode);
 


### PR DESCRIPTION
Repository is a fork from
[privacypass/challenge-bypass-extension](https://githupb.com/privacypass/challenge-bypass-extension). This commit updates GitHub actions to reflect this. Developer docs also have been updated to reflect this change.