### PR TITLE
Fix filtering of WWW-Authenticate header

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 18, 16]
+        node-version: [20, 18]
     steps:
       - name: Checking out
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -220,10 +220,14 @@ export const handleHeadersReceived =
             return;
         }
 
+        // Check if there's a valid PrivateToken header
         const privateTokenChl = details.responseHeaders.find(
             (x) => x.name.toLowerCase() == 'www-authenticate',
         )?.value;
         if (!privateTokenChl) {
+            return;
+        }
+        if (PrivateToken.parse(privateTokenChl).length === 0) {
             return;
         }
 


### PR DESCRIPTION
When this extension is installed and enabled, visiting a page with HTTP Basic Authentication will result in a request loop.

This comes from the fact that while the extension request WWW-Authenticate header is defined, it does not check synchronously for the presence of a PrivateToken auth scheme.

This commit adds a parsing of WWW-Authenticate header to confirm it is a valid PrivateToken header before redirecting/refreshing the current webpage.

This also fixes GitHub actions.

Closes #6 #8