### PR TITLE
Remove browser action

### DIFF
--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -21,10 +21,6 @@
         "webRequest",
         "webRequestBlocking"
     ],
-    "browser_action": {
-        "default_icon": "icons/32/grey.png",
-        "default_title": "Silk"
-    },
     "options_ui": {
         "page": "options/index.html"
     }

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -21,10 +21,6 @@
         "webRequest",
         "webRequestBlocking"
     ],
-    "browser_action": {
-        "default_icon": "icons/32/grey.png",
-        "default_title": "Silk"
-    },
     "options_ui": {
         "page": "options/index.html"
     },

--- a/platform/mv3/chromium/manifest.json
+++ b/platform/mv3/chromium/manifest.json
@@ -20,9 +20,6 @@
         "tabs",
         "webRequest"
     ],
-    "action": {
-        "default_icon": "icons/32/gold.png"
-    },
     "options_ui": {
         "page": "options/index.html"
     },


### PR DESCRIPTION
pp-browser-extension is not meant to do anything upon click. The browser action can therefore be removed.

Closes #10.