### PR TITLE
Add restriction on tab opening to the current active tab

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -298,7 +298,7 @@ export const handleHeadersReceived =
         }
         const redirectPromise = w3HeaderValue
             .then(async (value): Promise<void | chrome.webRequest.BlockingResponse> => {
-                if (value === null) {
+                if (!value) {
                     delete TOKENS[details.url];
                     return;
                 }
@@ -307,9 +307,7 @@ export const handleHeadersReceived =
                         getAuthorizationRule(details.url, `PrivateToken token=${value}`),
                     );
                 } else {
-                    if (value) {
-                        TOKENS[details.url] = value;
-                    }
+                    TOKENS[details.url] = value;
                 }
 
                 return { redirectUrl: details.url };

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -64,6 +64,19 @@ export const headerToToken = async (
             // API expects interactive Challenge at /challenge
             attesterURI = `${attesterURI}/challenge`;
 
+            // To minimize the number of tabs opened, we check if the requesting tab is the focused tab
+            const tabInfo: chrome.tabs.Tab | undefined = await new Promise((resolve) => {
+                chrome.tabs.get(tabId, resolve);
+            });
+            const tabWindow: chrome.windows.Window | undefined = await new Promise((resolve) => {
+                if (tabInfo) {
+                    chrome.windows.get(tabInfo.windowId, resolve);
+                }
+            });
+            if (!tabWindow?.focused || !tabInfo?.active) {
+                logger.debug('Not opening a new tab due to requesting tab not being active');
+                return undefined;
+            }
             const tab: chrome.tabs.Tab = await new Promise((resolve) =>
                 chrome.tabs.create({ url: attesterURI }, resolve),
             );


### PR DESCRIPTION
In the existing extension, any tab initiating a PrivateToken request for a trusted issuer is going to trigger the associated attester tab opening. This might interrupt the user flow.
This commit introduces an improvement to only allow the current active tab to open a new tab upon a PrivateToken request.