### PR TITLE
Release v4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "silk-privacy-pass-client",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "silk-privacy-pass-client",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "contributors": [
         "Suphanat Chunhapanya <pop@cloudflare.com>",
         "Armando Faz <armfazh@cloudflare.com>",

--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -2,7 +2,7 @@
     "name": "Silk - Privacy Pass Client",
     "manifest_version": 2,
     "description": "Client support for Privacy Pass anonymous authorization protocol.",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "icons": {
         "32": "icons/32/gold.png",
         "48": "icons/48/gold.png",

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -2,7 +2,7 @@
     "name": "Silk - Privacy Pass Client",
     "manifest_version": 2,
     "description": "Client support for Privacy Pass anonymous authorization protocol.",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "icons": {
         "32": "icons/32/gold.png",
         "48": "icons/48/gold.png",

--- a/platform/mv3/chromium/manifest.json
+++ b/platform/mv3/chromium/manifest.json
@@ -3,7 +3,7 @@
     "manifest_version": 3,
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp+7N/GLYPSBqf+O7fGOaLQ+3hIvXrhsjo8Pq73aSVw08YZRWIIsM+xRnaqdgcu3dXgQGjuVbFVD0nQzg2ymOJk40PSZ/EDdbmWmvD6IrKV88qdmLAlMCvgYW6oRQG5EIBNrmUOqQvTHpdaHrYxY3g4OQfaCe5mvYS64VG6Tb9f1G/UqUcNQzdo1A7x6ElCMjl+isMkt1in749KxgCmhHlZshQfCf1tXwcjhh09luatwP+KCFqCw0VPNMij1eBHi+Z1r43o1RNSTVoiot4mXHMej/rZiApG3U0eVfhp6yOLLakNGnzy1hR5OO00vlMVSyg2HR4VnvPyJuZ+VRNGBo7wIDAQAB",
     "description": "Client support for Privacy Pass anonymous authorization protocol.",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "icons": {
         "32": "icons/32/gold.png",
         "48": "icons/48/gold.png",


### PR DESCRIPTION
Update `package.json`, `package-lock.json`, as well as `manifest.json` to prepare for a release. Tag is going to be added via GitHub release management.

CHANGELOG
- Open new tab only if requested by the focused tab
- Remove browser action
- Fix WWW-Authenticate filtering
- Fix GitHub Action for Node 18+
- Update dependencies