### PR TITLE
Add refresh of attester when modified and once a day

### DIFF
--- a/platform/chromium/index.ts
+++ b/platform/chromium/index.ts
@@ -4,12 +4,15 @@ import {
     handleBeforeSendHeaders,
     handleHeadersReceived,
     handleInstall,
+    handleStartup,
 } from '../../src/background';
 
 const BROWSER = BROWSERS.CHROME;
 const STORAGE = chrome.storage.local;
 
 chrome.runtime.onInstalled.addListener(handleInstall(STORAGE));
+
+chrome.runtime.onStartup.addListener(handleStartup(STORAGE));
 
 chrome.webRequest.onBeforeRequest.addListener(handleBeforeRequest(), { urls: ['<all_urls>'] }, [
     'blocking',

--- a/platform/firefox/index.ts
+++ b/platform/firefox/index.ts
@@ -3,12 +3,15 @@ import {
     handleBeforeSendHeaders,
     handleHeadersReceived,
     handleInstall,
+    handleStartup,
 } from '../../src/background';
 
 const BROWSER = BROWSERS.FIREFOX;
 const STORAGE = browser.storage.local;
 
 chrome.runtime.onInstalled.addListener(handleInstall(STORAGE));
+
+chrome.runtime.onStartup.addListener(handleStartup(STORAGE));
 
 chrome.webRequest.onBeforeSendHeaders.addListener(
     handleBeforeSendHeaders(STORAGE),

--- a/platform/mv3/chromium/index.ts
+++ b/platform/mv3/chromium/index.ts
@@ -4,12 +4,15 @@ import {
     handleBeforeSendHeaders,
     handleHeadersReceived,
     handleInstall,
+    handleStartup,
 } from '../../../src/background';
 
 const BROWSER = BROWSERS.CHROME;
 const STORAGE = chrome.storage.local;
 
 chrome.runtime.onInstalled.addListener(handleInstall(STORAGE));
+
+chrome.runtime.onStartup.addListener(handleStartup(STORAGE));
 
 chrome.webRequest.onBeforeRequest.addListener(handleBeforeRequest(), { urls: ['<all_urls>'] });
 

--- a/src/background/attesters.ts
+++ b/src/background/attesters.ts
@@ -1,8 +1,5 @@
-import { getSettings } from '../common';
+export { refreshAttesterLookupByIssuerKey } from '../common';
 import { STORAGE_ID_ATTESTER_CONFIGURATION } from './const';
-import { getLogger } from './logger';
-
-import { IssuerConfig } from '@cloudflare/privacypass-ts';
 
 // return an attester challenge URI based on the public key presented in 401 response
 export const keyToAttesterURI = async (
@@ -18,41 +15,4 @@ export const keyToAttesterURI = async (
         storageItem[STORAGE_ID_ATTESTER_CONFIGURATION];
 
     return attestersByIssuerKey[key];
-};
-
-export const refreshAttesterLookupByIssuerKey = async (storage: chrome.storage.StorageArea) => {
-    // Force reset associations between public keys and issuers that trust each attester that we know about
-    const attestersByIssuerKey = new Map<string, string>();
-
-    const { attesters, serviceWorkerMode: mode } = getSettings();
-    const logger = getLogger(mode);
-
-    // Populate issuer keys for issuers that trust our ATTESTERS
-    for (const attester of attesters) {
-        const nowTimestamp = Date.now();
-
-        // Connect to each of the ATTESTERS we know about for their issuer directory
-        const response = await fetch(`${attester}/v1/private-token-issuer-directory`);
-        if (!response.ok) {
-            logger.log(`"${attester}" issuer keys not available, attester will not be used.`);
-            return;
-        }
-
-        const directory: Record<string, IssuerConfig> = await response.json();
-        // for each attester in the directory
-        for (const { 'token-keys': tokenKeys } of Object.values(directory)) {
-            for (const key of tokenKeys) {
-                const notBefore = key['not-before'];
-                if (!notBefore || notBefore > nowTimestamp) {
-                    continue;
-                }
-                attestersByIssuerKey.set(key['token-key'], attester);
-            }
-        }
-        storage.set({
-            [STORAGE_ID_ATTESTER_CONFIGURATION]: Object.fromEntries(attestersByIssuerKey),
-        });
-    }
-
-    logger.info('Attester lookup by Issuer key populated');
 };

--- a/src/background/const.ts
+++ b/src/background/const.ts
@@ -1,3 +1,5 @@
+export * from '../common';
+
 export const BROWSERS = {
     CHROME: 'Chrome',
     FIREFOX: 'Firefox',
@@ -7,5 +9,3 @@ export type BROWSERS = (typeof BROWSERS)[keyof typeof BROWSERS];
 
 export const PRIVACY_PASS_API_REPLAY_HEADER = 'private-token-client-replay';
 export const PRIVACY_PASS_API_REPLAY_URI = 'https://no-reply.private-token.research.cloudflare.com';
-
-export const STORAGE_ID_ATTESTER_CONFIGURATION = 'attesters_by_issuer_key';

--- a/src/background/pubVerifToken.ts
+++ b/src/background/pubVerifToken.ts
@@ -9,7 +9,11 @@ export async function fetchPublicVerifToken(
 
     const attesterToken: string = await new Promise((resolve) => {
         storage.onChanged.addListener(async (changes) => {
-            for (const [, { newValue }] of Object.entries(changes)) {
+            for (const [, value] of Object.entries(changes)) {
+                if (!value.newValue) {
+                    continue;
+                }
+                const newValue = value.newValue;
                 if (
                     newValue[originTabId] &&
                     newValue[originTabId].hasOwnProperty('attestationData') && // eslint-disable-line no-prototype-builtins

--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -1,0 +1,1 @@
+export const STORAGE_ID_ATTESTER_CONFIGURATION = 'attesters_by_issuer_key';

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,1 +1,3 @@
+export * from './const';
+export * from './logger';
 export * from './settings';

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import { SERVICE_WORKER_MODE } from '../common';
+import { SERVICE_WORKER_MODE } from './settings';
 
 interface Logger {
     info: (...obj: unknown[]) => void; // Log an info level message

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -1,3 +1,7 @@
+import { IssuerConfig } from '@cloudflare/privacypass-ts';
+import { STORAGE_ID_ATTESTER_CONFIGURATION } from './const';
+import { getLogger } from './logger';
+
 export const SETTING_NAMES = {
     SERVICE_WORKER_MODE: 'serviceWorkerMode',
     ATTESTERS: 'attesters',
@@ -54,7 +58,44 @@ export function getSettings(): Settings {
     return settings;
 }
 
-export function saveSettings(
+export const refreshAttesterLookupByIssuerKey = async (storage: chrome.storage.StorageArea) => {
+    // Force reset associations between public keys and issuers that trust each attester that we know about
+    const attestersByIssuerKey = new Map<string, string>();
+
+    const { attesters, serviceWorkerMode: mode } = getSettings();
+    const logger = getLogger(mode);
+
+    // Populate issuer keys for issuers that trust our ATTESTERS
+    for (const attester of attesters) {
+        const nowTimestamp = Date.now();
+
+        // Connect to each of the ATTESTERS we know about for their issuer directory
+        const response = await fetch(`${attester}/v1/private-token-issuer-directory`);
+        if (!response.ok) {
+            logger.log(`"${attester}" issuer keys not available, attester will not be used.`);
+            return;
+        }
+
+        const directory: Record<string, IssuerConfig> = await response.json();
+        // for each attester in the directory
+        for (const { 'token-keys': tokenKeys } of Object.values(directory)) {
+            for (const key of tokenKeys) {
+                const notBefore = key['not-before'];
+                if (!notBefore || notBefore > nowTimestamp) {
+                    continue;
+                }
+                attestersByIssuerKey.set(key['token-key'], attester);
+            }
+        }
+        storage.set({
+            [STORAGE_ID_ATTESTER_CONFIGURATION]: Object.fromEntries(attestersByIssuerKey),
+        });
+    }
+
+    logger.info('Attester lookup by Issuer key populated');
+};
+
+export async function saveSettings(
     storage: chrome.storage.StorageArea,
     name: SettingsKeys,
     value: string,
@@ -62,6 +103,7 @@ export function saveSettings(
     switch (name) {
         case 'attesters':
             settings[name] = rawSettingToSettingAttester(value);
+            await refreshAttesterLookupByIssuerKey(storage);
             break;
         case 'serviceWorkerMode':
             if (


### PR DESCRIPTION
This allows new attesters to be added without a new installation/upgrade of the extension.